### PR TITLE
[Minor] Fix typo for project link on AT wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oshietegoo-grab
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [教えて! goo](https://wiki.archiveteam.org/index.php?title=教えて! goo)
+More information about the archiving project can be found on the ArchiveTeam wiki: [教えて! goo](https://wiki.archiveteam.org/index.php?title=Oshiete!_goo)
 
 ## Setup instructions
 


### PR DESCRIPTION
Fixes the link for README.md;
https://wiki.archiveteam.org/index.php?title=教えて! goo → https://wiki.archiveteam.org/index.php/Oshiete!_Goo